### PR TITLE
docs: supplement the instruction for v1.0.2

### DIFF
--- a/upgrades/v1.0.2.md
+++ b/upgrades/v1.0.2.md
@@ -27,6 +27,13 @@ IMAGE_TAG__KROMA_NODE=v1.0.2
 IMAGE_TAG__KROMA_VALIDATOR=v1.0.2
 ```
 
+Especially with this upgrade, the name `proposer` has been changed to `sequencer`, requiring modifications in the 
+`rollup.json` file. The changes are as follows:
+
+- `max_proposer_drift` -> `max_sequencer_drift`
+- `proposer_window_size` -> `seq_window_size`
+
+Before running a full node or validator, please check these changes in the `rollup.json` file.
 
 ### Start Kroma
 


### PR DESCRIPTION
Notice that there were some changes in `rollup.json` for `v1.0.2`.
This will be helpful for users in running a full node or validator without any errors due to the changes in `rollup.json`.