### PR TITLE
feat: disable snapshot and increase max peers

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -49,4 +49,6 @@ exec geth \
     --bootnodes="$BOOT_NODES" \
     --circuitparams.maxtxs=0 \
     --gpo.maxprice=100000000 \
+    --maxpeers=200 \
+    --snapshot=false \
     "$@"


### PR DESCRIPTION
Disable snapshot and increase max num of peers to 200.
