### PR TITLE
Updating docker-compose<network>.yml

### DIFF
--- a/docker-compose-mainnet.yml
+++ b/docker-compose-mainnet.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   kroma-geth:
     container_name: kroma-geth

--- a/docker-compose-sepolia.yml
+++ b/docker-compose-sepolia.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   kroma-geth:
     container_name: kroma-geth

--- a/upgrades/v1.4.2.md
+++ b/upgrades/v1.4.2.md
@@ -18,9 +18,8 @@ The activation time of Ecotone upgrade is scheduled as below:
 First of all, pull the latest kroma-up and checkout to v1.4.2.
 
 ```bash
-git fetch origin
 git pull origin main
-git checkout v1.4.2
+git checkout tags/v1.4.2
 ```
 
 ### Stop Kroma

--- a/upgrades/v1.4.2.md
+++ b/upgrades/v1.4.2.md
@@ -20,6 +20,7 @@ First of all, pull the latest kroma-up and checkout to v1.4.2.
 ```bash
 git fetch origin
 git pull origin main
+git checkout v1.4.2
 ```
 
 ### Stop Kroma

--- a/upgrades/v1.4.2.md
+++ b/upgrades/v1.4.2.md
@@ -19,7 +19,6 @@ First of all, pull the latest kroma-up and checkout to v1.4.2.
 
 ```bash
 git pull origin main
-git checkout tags/v1.4.2
 ```
 
 ### Stop Kroma

--- a/upgrades/v1.4.2.md
+++ b/upgrades/v1.4.2.md
@@ -18,6 +18,7 @@ The activation time of Ecotone upgrade is scheduled as below:
 First of all, pull the latest kroma-up and checkout to v1.4.2.
 
 ```bash
+git fetch origin
 git pull origin main
 ```
 


### PR DESCRIPTION
I have updated the files removing the versions of the docker-compose, since they are not required and the warning pops up, this way we avoid the warning.

Fixes #48
