### PR TITLE
fix: move historical rpc flag to extended args

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,6 +21,10 @@ else
   echo "$GETH_CHAINDATA_DIR exists."
 fi
 
+if [ -n "${HISTORICAL_RPC:-}" ]; then
+  export EXTENDED_ARG="${EXTENDED_ARG:-} --rollup.historicalrpc=${HISTORICAL_RPC}"
+fi
+
 if [ "${DISABLE_MIGRATION:-}" = "true" ]; then
   export EXTENDED_ARG="${EXTENDED_ARG:-} --kroma.migration.disable=true"
 fi
@@ -56,6 +60,5 @@ exec geth \
     --gpo.maxprice=100000000 \
     --maxpeers=200 \
     --snapshot=false \
-    --rollup.historicalrpc=${HISTORICAL_RPC} \
     ${EXTENDED_ARG:-} \
     "$@"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -6,12 +6,9 @@ KROMA_PATH="/.kroma"
 GETH_DATA_DIR="$KROMA_PATH/db"
 GETH_CHAINDATA_DIR="$GETH_DATA_DIR/geth/chaindata"
 GENESIS_FILE_PATH="${GENESIS_FILE_PATH:-$KROMA_PATH/config/genesis.json}"
-CHAIN_ID=${CHAIN_ID}
 RPC_PORT="${RPC_PORT:-8545}"
 WS_PORT="${WS_PORT:-8546}"
 JWT_SECRET_PATH="${JWT_SECRET_PATH:-$KROMA_PATH/keys/jwt-secret.txt}"
-BOOT_NODES=${BOOT_NODES}
-HISTORICAL_RPC=${HISTORICAL_RPC}
 
 if [ ! -d "$GETH_CHAINDATA_DIR" ]; then
   echo "$GETH_CHAINDATA_DIR missing, running init"
@@ -21,7 +18,7 @@ else
   echo "$GETH_CHAINDATA_DIR exists."
 fi
 
-if [ -n "${HISTORICAL_RPC:-}" ]; then
+if [ -n "${HISTORICAL_RPC}" ]; then
   export EXTENDED_ARG="${EXTENDED_ARG:-} --rollup.historicalrpc=${HISTORICAL_RPC}"
 fi
 


### PR DESCRIPTION
Moved historical RPC flag to `EXTENDED_ARG` and add it only if `HISTORICAL_RPC` is specified.