### PR TITLE
fix: fixed an issue in the part where EXTENDED_ARG is used

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -57,5 +57,5 @@ exec geth \
     --maxpeers=200 \
     --snapshot=false \
     --rollup.historicalrpc=${HISTORICAL_RPC} \
-    $EXTENDED_ARG \
+    ${EXTENDED_ARG:-} \
     "$@"


### PR DESCRIPTION
When DISABLE_MIGRATION is not set to true, EXTENDED_ARG is not defined, causing geth to fail to start.
